### PR TITLE
Include the `disqus_identifier` variable

### DIFF
--- a/web/templates/page/show.html.eex
+++ b/web/templates/page/show.html.eex
@@ -23,6 +23,7 @@
   <script type="text/javascript">
     /* * * CONFIGURATION VARIABLES * * */
     var disqus_shortname = 'micheladaio';
+    var disqus_identifier = '<%= page_url(@conn, :show, @post.permalink) %>';
 
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {


### PR DESCRIPTION
https://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables#disqus_identifier

It is currently just using the page url with all the parameters by default.  It would be ideal to use the post's id, but that would delete all current comments from our existing blog posts.  
